### PR TITLE
updated code for Magento 1.9.3 compatibility

### DIFF
--- a/K2_Pathes/app/code/local/K2service/Patch/Model/Resource/Catalog/Product/Indexer/Eav/Source.php
+++ b/K2_Pathes/app/code/local/K2service/Patch/Model/Resource/Catalog/Product/Indexer/Eav/Source.php
@@ -49,14 +49,14 @@ class K2service_Patch_Model_Resource_Catalog_Product_Indexer_Eav_Source
         $productValueExpression = $adapter->getCheckSql('pvs.value_id > 0', 'pvs.value', 'pvd.value');
         $select = $adapter->select()
             ->from(
-                ['pvd' => $this->getValueTable('catalog/product', 'varchar')],
+                ['pvd' => $this->getValueTable('catalog/product', 'text')],
                 ['entity_id', 'attribute_id'])
             ->join(
                 ['cs' => $this->getTable('core/store')],
                 '',
                 ['store_id'])
             ->joinLeft(
-                ['pvs' => $this->getValueTable('catalog/product', 'varchar')],
+                ['pvs' => $this->getValueTable('catalog/product', 'text')],
                 'pvs.entity_id = pvd.entity_id AND pvs.attribute_id = pvd.attribute_id'
                 . ' AND pvs.store_id=cs.store_id',
                 ['value' => $productValueExpression])


### PR DESCRIPTION
In Magento 1.9.3, the value types have been switched from `varchar` to `text`. See https://github.com/OpenMage/magento-mirror/commit/d48bebc211cc216aaf78bdf25d7f0b0143d6333b#diff-ee2fcddfbe1ac1200b37e93df420ab2a.